### PR TITLE
chore: fix some unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12218,7 +12218,7 @@
     },
     "packages/client": {
       "name": "@openfeature/web-sdk",
-      "version": "0.3.0-experimental",
+      "version": "0.3.1-experimental",
       "license": "Apache-2.0",
       "devDependencies": {
         "@openfeature/shared": "0.0.2"

--- a/packages/server/test/hooks.spec.ts
+++ b/packages/server/test/hooks.spec.ts
@@ -574,7 +574,6 @@ describe('Hooks', () => {
                 expect(invocationErrorHook.error).not.toHaveBeenCalled();
                 expect(clientErrorHook.error).not.toHaveBeenCalled();
                 expect(globalErrorHook.error).not.toHaveBeenCalled();
-                done();
               } catch (err) {
                 done(err);
               }


### PR DESCRIPTION
The main issue I found here was that the "mock error" providers weren't throwing. In JS, returning an error isn't really an error... it's just a function returning an error - you have to either reject a promise (if it's an async function) or throw something. That was the main thing causing the problem with the tests.

These are both abnormal executions:

```ts
return Promise.reject('oh noes!');
```

```ts
throw new Error('oh noes!');
```

This is weird, bit it's normal, non-exceptional execution:

```ts
return new Error('this is silly, but its normal execution!');
```
